### PR TITLE
define custom index.d.ts (and use it internally)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,17 +24,17 @@
   },
   "module": "./dist/rxstate.core.es2017.js",
   "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "typings": "./src/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "src/index.d.ts"
   ],
   "scripts": {
-    "build": "npm run build:ts && npm run build:esm2017 && npm run build:esm2019 && npm run build:cjs:dev && npm run build:cjs:prod",
+    "build": "npm run build:esm2017 && npm run build:esm2019 && npm run build:cjs:dev && npm run build:cjs:prod",
     "build:esm2019": "esbuild src/index.ts --bundle --outfile=./dist/rxstate.core.es2019.mjs --target=es2019 --external:rxjs --format=esm --sourcemap",
     "build:esm2017": "esbuild src/index.ts --bundle --outfile=./dist/rxstate.core.es2017.js --target=es2017 --external:rxjs --format=esm --sourcemap",
     "build:cjs:dev": "esbuild src/index.ts --bundle --outfile=./dist/rxstate.core.cjs.development.js --target=es2015 --external:rxjs --format=cjs --sourcemap",
     "build:cjs:prod": "esbuild src/index.ts --bundle --outfile=./dist/rxstate.core.cjs.production.min.js --target=es2015 --external:rxjs --format=cjs --minify --sourcemap",
-    "build:ts": "tsc -p ./tsconfig-build.json --outDir ./dist --skipLibCheck --emitDeclarationOnly",
     "test": "jest --coverage",
     "lint": "prettier --check README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "format": "prettier --write README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",

--- a/src/StateObservable.ts
+++ b/src/StateObservable.ts
@@ -1,20 +1,7 @@
-import { Observable } from "rxjs"
-import { PipeState } from "./PipeState"
+import type { StatePromise as IStatePromise } from "./index.d"
 
-export class StatePromise<T> extends Promise<T> {
+export class StatePromise<T> extends Promise<T> implements IStatePromise<T> {
   constructor(cb: (res: (value: T) => void, rej: any) => void) {
     super(cb)
   }
-}
-
-export interface StateObservable<T> extends Observable<T> {
-  getRefCount: () => number
-  getValue: (filter?: (value: T) => boolean) => T | StatePromise<T>
-  pipe: PipeState<T>
-}
-
-export interface DefaultedStateObservable<T> extends StateObservable<T> {
-  getValue: (filter?: (value: T) => boolean) => T
-  getDefaultValue: () => T
-  pipe: PipeState<T>
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,11 +1,19 @@
-export class NoSubscribersError extends Error {
+import type {
+  NoSubscribersError as INoSubscribersError,
+  EmptyObservableError as IEmptyObservableError,
+} from "./index.d"
+
+export class NoSubscribersError extends Error implements INoSubscribersError {
   constructor() {
     super()
     this.name = "NoSubscribersError"
   }
 }
 
-export class EmptyObservableError extends Error {
+export class EmptyObservableError
+  extends Error
+  implements IEmptyObservableError
+{
   constructor() {
     super()
     this.name = "EmptyObservableError"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,209 @@
+import type { Observable, OperatorFunction, UnaryFunction } from "rxjs"
+
+interface PipeState<T> {
+  <A>(defaultOp: WithDefaultOperator<T, A>): DefaultedStateObservable<T | A>
+  <A, B>(
+    op1: OperatorFunction<T, A>,
+    defaultOp: WithDefaultOperator<A, B>,
+  ): DefaultedStateObservable<A | B>
+  <A, B, C>(
+    op1: OperatorFunction<T, A>,
+    op2: OperatorFunction<A, B>,
+    defaultOp: WithDefaultOperator<B, C>,
+  ): DefaultedStateObservable<B | C>
+  <A, B, C, D>(
+    op1: OperatorFunction<T, A>,
+    op2: OperatorFunction<A, B>,
+    op3: OperatorFunction<B, C>,
+    defaultOp: WithDefaultOperator<C, D>,
+  ): DefaultedStateObservable<C | D>
+  <A, B, C, D, E>(
+    op1: OperatorFunction<T, A>,
+    op2: OperatorFunction<A, B>,
+    op3: OperatorFunction<B, C>,
+    op4: OperatorFunction<C, D>,
+    defaultOp: WithDefaultOperator<D, E>,
+  ): DefaultedStateObservable<D | E>
+  <A, B, C, D, E, F>(
+    op1: OperatorFunction<T, A>,
+    op2: OperatorFunction<A, B>,
+    op3: OperatorFunction<B, C>,
+    op4: OperatorFunction<C, D>,
+    op5: OperatorFunction<D, E>,
+    defaultOp: WithDefaultOperator<E, F>,
+  ): DefaultedStateObservable<E | F>
+  <A, B, C, D, E, F, G>(
+    op1: OperatorFunction<T, A>,
+    op2: OperatorFunction<A, B>,
+    op3: OperatorFunction<B, C>,
+    op4: OperatorFunction<C, D>,
+    op5: OperatorFunction<D, E>,
+    op6: OperatorFunction<E, F>,
+    defaultOp: WithDefaultOperator<F, G>,
+  ): DefaultedStateObservable<F | G>
+  <A, B, C, D, E, F, G, H>(
+    op1: OperatorFunction<T, A>,
+    op2: OperatorFunction<A, B>,
+    op3: OperatorFunction<B, C>,
+    op4: OperatorFunction<C, D>,
+    op5: OperatorFunction<D, E>,
+    op6: OperatorFunction<E, F>,
+    op7: OperatorFunction<F, G>,
+    defaultOp: WithDefaultOperator<G, H>,
+  ): DefaultedStateObservable<G | H>
+  <A, B, C, D, E, F, G, H, I>(
+    op1: OperatorFunction<T, A>,
+    op2: OperatorFunction<A, B>,
+    op3: OperatorFunction<B, C>,
+    op4: OperatorFunction<C, D>,
+    op5: OperatorFunction<D, E>,
+    op6: OperatorFunction<E, F>,
+    op7: OperatorFunction<F, G>,
+    op8: OperatorFunction<G, H>,
+    defaultOp: WithDefaultOperator<H, I>,
+  ): DefaultedStateObservable<H | I>
+  (): StateObservable<T>
+  <A>(op1: OperatorFunction<T, A>): StateObservable<A>
+  <A, B>(
+    op1: OperatorFunction<T, A>,
+    op2: OperatorFunction<A, B>,
+  ): StateObservable<B>
+  <A, B, C>(
+    op1: OperatorFunction<T, A>,
+    op2: OperatorFunction<A, B>,
+    op3: OperatorFunction<B, C>,
+  ): StateObservable<C>
+  <A, B, C, D>(
+    op1: OperatorFunction<T, A>,
+    op2: OperatorFunction<A, B>,
+    op3: OperatorFunction<B, C>,
+    op4: OperatorFunction<C, D>,
+  ): StateObservable<D>
+  <A, B, C, D, E>(
+    op1: OperatorFunction<T, A>,
+    op2: OperatorFunction<A, B>,
+    op3: OperatorFunction<B, C>,
+    op4: OperatorFunction<C, D>,
+    op5: OperatorFunction<D, E>,
+  ): StateObservable<E>
+  <A, B, C, D, E, F>(
+    op1: OperatorFunction<T, A>,
+    op2: OperatorFunction<A, B>,
+    op3: OperatorFunction<B, C>,
+    op4: OperatorFunction<C, D>,
+    op5: OperatorFunction<D, E>,
+    op6: OperatorFunction<E, F>,
+  ): StateObservable<F>
+  <A, B, C, D, E, F, G>(
+    op1: OperatorFunction<T, A>,
+    op2: OperatorFunction<A, B>,
+    op3: OperatorFunction<B, C>,
+    op4: OperatorFunction<C, D>,
+    op5: OperatorFunction<D, E>,
+    op6: OperatorFunction<E, F>,
+    op7: OperatorFunction<F, G>,
+  ): StateObservable<G>
+  <A, B, C, D, E, F, G, H>(
+    op1: OperatorFunction<T, A>,
+    op2: OperatorFunction<A, B>,
+    op3: OperatorFunction<B, C>,
+    op4: OperatorFunction<C, D>,
+    op5: OperatorFunction<D, E>,
+    op6: OperatorFunction<E, F>,
+    op7: OperatorFunction<F, G>,
+    op8: OperatorFunction<G, H>,
+  ): StateObservable<H>
+  <A, B, C, D, E, F, G, H, I>(
+    op1: OperatorFunction<T, A>,
+    op2: OperatorFunction<A, B>,
+    op3: OperatorFunction<B, C>,
+    op4: OperatorFunction<C, D>,
+    op5: OperatorFunction<D, E>,
+    op6: OperatorFunction<E, F>,
+    op7: OperatorFunction<F, G>,
+    op8: OperatorFunction<G, H>,
+    op9: OperatorFunction<H, I>,
+  ): StateObservable<I>
+  <A, B, C, D, E, F, G, H, I>(
+    op1: OperatorFunction<T, A>,
+    op2: OperatorFunction<A, B>,
+    op3: OperatorFunction<B, C>,
+    op4: OperatorFunction<C, D>,
+    op5: OperatorFunction<D, E>,
+    op6: OperatorFunction<E, F>,
+    op7: OperatorFunction<F, G>,
+    op8: OperatorFunction<G, H>,
+    op9: OperatorFunction<H, I>,
+    ...operations: OperatorFunction<any, any>[]
+  ): StateObservable<unknown>
+}
+
+export declare class StatePromise<T> extends Promise<T> {
+  constructor(cb: (res: (value: T) => void, rej: any) => void)
+}
+export interface StateObservable<T> extends Observable<T> {
+  getRefCount: () => number
+  getValue: (filter?: (value: T) => boolean) => T | StatePromise<T>
+  pipe: PipeState<T>
+}
+export interface DefaultedStateObservable<T> extends StateObservable<T> {
+  getValue: (filter?: (value: T) => boolean) => T
+  getDefaultValue: () => T
+  pipe: PipeState<T>
+}
+
+export interface WithDefaultOperator<T, R>
+  extends UnaryFunction<Observable<T>, DefaultedStateObservable<T | R>> {}
+export declare function withDefault<T, D>(
+  defaultValue: D,
+): WithDefaultOperator<T, D>
+
+export declare class NoSubscribersError extends Error {
+  constructor()
+}
+export declare class EmptyObservableError extends Error {
+  constructor()
+}
+
+/**
+ * Creates a StateObservable
+ *
+ * @param {Observable<T>} observable - Source observable
+ * @param {T} [defaultValue] - Default value that will be used if the source
+ * has not emitted.
+ * @returns A StateObservable, which can be used for composing other streams that
+ * depend on it. The shared subscription is closed as soon as there are no
+ * subscribers, also the state is cleared.
+ *
+ * @remarks If the source Observable doesn't synchronously emit a value upon
+ * subscription, then the state Observable will synchronously emit the
+ * defaultValue if present.
+ */
+export declare function state<T>(
+  observable: Observable<T>,
+  defaultValue: T,
+): DefaultedStateObservable<T>
+export declare function state<T>(observable: Observable<T>): StateObservable<T>
+/**
+ * Creates a factory of StateObservables
+ *
+ * @param getObservable - Factory of Observables.
+ * @param [defaultValue] - Function or value that will be used if the source
+ * has not emitted.
+ * @returns A function with the same parameters as the factory function, which
+ * returns the StateObservable for those arguements, which can be used for
+ * composing other streams that depend on it. The shared subscription is closed
+ * as soon as there are no subscribers, also the state and all in memory
+ * references to the returned Observable are cleared.
+ *
+ * @remarks If the Observable doesn't synchronously emit a value upon the first
+ * subscription, then the state Observable will synchronously emit the
+ * defaultValue if present.
+ */
+export declare function state<A extends unknown[], O>(
+  getObservable: (...args: A) => Observable<O>,
+  defaultValue: O | ((...args: A) => O),
+): (...args: A) => DefaultedStateObservable<O>
+export declare function state<A extends unknown[], O>(
+  getObservable: (...args: A) => Observable<O>,
+): (...args: A) => StateObservable<O>

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,57 +1,10 @@
-import { Observable } from "rxjs"
+import type { state as IState } from "../index.d"
+import { EMPTY_VALUE } from "../internal/empty-value"
 import stateFactory from "./stateFactory"
 import stateSingle from "./stateSingle"
-import { EMPTY_VALUE } from "../internal/empty-value"
-import { DefaultedStateObservable, StateObservable } from "../StateObservable"
 
-/**
- * Creates a StateObservable
- *
- * @param {Observable<T>} observable - Source observable
- * @param {T} [defaultValue] - Default value that will be used if the source
- * has not emitted.
- * @returns A StateObservable, which can be used for composing other streams that
- * depend on it. The shared subscription is closed as soon as there are no
- * subscribers, also the state is cleared.
- *
- * @remarks If the source Observable doesn't synchronously emit a value upon
- * subscription, then the state Observable will synchronously emit the
- * defaultValue if present.
- */
-export function state<T>(observable: Observable<T>): StateObservable<T>
-
-export function state<T>(
-  observable: Observable<T>,
-  defaultValue: T,
-): DefaultedStateObservable<T>
-
-/**
- * Creates a factory of StateObservables
- *
- * @param getObservable - Factory of Observables.
- * @param [defaultValue] - Function or value that will be used if the source
- * has not emitted.
- * @returns A function with the same parameters as the factory function, which
- * returns the StateObservable for those arguements, which can be used for
- * composing other streams that depend on it. The shared subscription is closed
- * as soon as there are no subscribers, also the state and all in memory
- * references to the returned Observable are cleared.
- *
- * @remarks If the Observable doesn't synchronously emit a value upon the first
- * subscription, then the state Observable will synchronously emit the
- * defaultValue if present.
- */
-export function state<A extends unknown[], O>(
-  getObservable: (...args: A) => Observable<O>,
-): (...args: A) => StateObservable<O>
-
-export function state<A extends unknown[], O>(
-  getObservable: (...args: A) => Observable<O>,
-  defaultValue: O | ((...args: A) => O),
-): (...args: A) => DefaultedStateObservable<O>
-
-export function state(observable: any, defaultValue?: any) {
-  return (
-    typeof observable === "function" ? (stateFactory as any) : stateSingle
-  )(observable, arguments.length > 1 ? defaultValue : EMPTY_VALUE)
-}
+export const state: typeof IState = (...args: any[]) =>
+  (typeof args[0] === "function" ? (stateFactory as any) : stateSingle)(
+    args[0],
+    args.length > 1 ? args[1] : EMPTY_VALUE,
+  )

--- a/src/withDefault.ts
+++ b/src/withDefault.ts
@@ -1,10 +1,8 @@
-import { Observable, UnaryFunction } from "rxjs"
+import type { Observable } from "rxjs"
+import type { withDefault as IWithDefault } from "./index.d"
 import { state } from "./state"
-import { DefaultedStateObservable } from "./StateObservable"
 
-export interface WithDefaultOperator<T, R>
-  extends UnaryFunction<Observable<T>, DefaultedStateObservable<T | R>> {}
-
-export function withDefault<T, D>(defaultValue: D): WithDefaultOperator<T, D> {
-  return (source$) => state<D | T>(source$, defaultValue)
-}
+export const withDefault: typeof IWithDefault =
+  <D>(defaultValue: D) =>
+  <T>(source$: Observable<T>) =>
+    state<D | T>(source$, defaultValue)

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": ["**/*.test.*"]
-}


### PR DESCRIPTION
This is something that I've wanted to do for a while and today I finally decided to get to it:

The idea is: let's define by hand the typings of the public API in a `index.d.ts` file and then let's use that for both the typings of the public API and also for ensuring that the code that's publicly exported is compliant (implements) those typings.

Ideally, in the future, I would like to also have a CI task that ensures that the types that would get generated automatically are 100% compliant with the the types that have been manually defined in our `index.d.ts`... That way, if for instance we forgot to export a public function, then the CI would fail.